### PR TITLE
Use Authorization header in license request

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -190,11 +190,11 @@ func (a *agent) fetch() ([]byte, error) {
 		return nil, err
 	}
 	q := hex.EncodeToString(id)
-	url := fmt.Sprintf("%s/%s", a.svcURL, q)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequest(http.MethodGet, a.svcURL, nil)
 	if err != nil {
 		return nil, err
 	}
+	req.Header.Set("Authorization", q)
 	req.Header.Set("Content-Type", "application/json")
 	res, err := http.DefaultClient.Do(req)
 	if res != nil {

--- a/license.go
+++ b/license.go
@@ -35,6 +35,9 @@ func (l License) Validate() error {
 	if l.CreatedAt.UTC().After(now) {
 		return errors.Wrap(ErrMalformedEntity, ErrIssuedAt)
 	}
+	if !l.Active {
+		return ErrLicenseValidation
+	}
 	return nil
 }
 

--- a/service/api/endpoint.go
+++ b/service/api/endpoint.go
@@ -91,7 +91,7 @@ func viewByDeviceIDEndpoint(svc license.Service) endpoint.Endpoint {
 			return nil, err
 		}
 
-		return svc.RetrieveByDeviceID(ctx, req.id)
+		return svc.RetrieveByDeviceID(ctx, req.token)
 	}
 }
 func updateEndpoint(svc license.Service) endpoint.Endpoint {

--- a/service/api/transport.go
+++ b/service/api/transport.go
@@ -62,7 +62,7 @@ func MakeHandler(tracer opentracing.Tracer, l log.Logger, svc license.Service) h
 		opts...,
 	))
 
-	r.Get("/licenses/devices/:id", kithttp.NewServer(
+	r.Get("/licenses/devices", kithttp.NewServer(
 		kitot.TraceServer(tracer, "fetch_by_device_id")(viewByDeviceIDEndpoint(svc)),
 		decodeView,
 		encodeFetch,
@@ -146,7 +146,6 @@ func decodeView(_ context.Context, r *http.Request) (interface{}, error) {
 
 	req := licenseReq{
 		token: r.Header.Get("Authorization"),
-		id:    bone.GetValue(r, "id"),
 	}
 
 	return req, nil


### PR DESCRIPTION
Use authorization header rather than using the client ID path parameter.